### PR TITLE
Update master data category handling and add text exports

### DIFF
--- a/client/src/components/common/ConfirmationDialog.tsx
+++ b/client/src/components/common/ConfirmationDialog.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode } from "react";
+import type { MouseEvent } from "react";
 import { FiAlertTriangle, FiX } from "react-icons/fi";
 
 interface ConfirmationDialogProps {
@@ -57,8 +57,8 @@ export const ConfirmationDialog = ({
 
   const styles = getVariantStyles();
 
-  const handleBackdropClick = (e: React.MouseEvent) => {
-    if (e.target === e.currentTarget) {
+  const handleBackdropClick = (event: MouseEvent<HTMLDivElement>) => {
+    if (event.target === event.currentTarget) {
       onClose();
     }
   };

--- a/client/src/components/common/SyncStatus.tsx
+++ b/client/src/components/common/SyncStatus.tsx
@@ -1,4 +1,4 @@
-import { FiWifi, FiWifiOff, FiRefreshCw, FiCheckCircle, FiAlertTriangle } from "react-icons/fi";
+import { FiWifiOff, FiRefreshCw, FiCheckCircle, FiAlertTriangle } from "react-icons/fi";
 import { useMasterData } from "../../contexts/MasterDataContext";
 
 export const SyncStatus = () => {

--- a/client/src/config/firebase.ts
+++ b/client/src/config/firebase.ts
@@ -1,6 +1,6 @@
 import { initializeApp } from "firebase/app";
-import { getFirestore, connectFirestoreEmulator } from "firebase/firestore";
-import { getAnalytics } from "firebase/analytics";
+import { getFirestore } from "firebase/firestore";
+import { getAnalytics, type Analytics } from "firebase/analytics";
 
 // Firebase configuration
 const firebaseConfig = {
@@ -20,7 +20,7 @@ const app = initializeApp(firebaseConfig);
 export const db = getFirestore(app);
 
 // Initialize Analytics (only in production)
-let analytics: any = null;
+let analytics: Analytics | null = null;
 if (typeof window !== "undefined" && process.env.NODE_ENV === "production") {
   analytics = getAnalytics(app);
 }

--- a/client/src/contexts/MasterDataContext.tsx
+++ b/client/src/contexts/MasterDataContext.tsx
@@ -39,11 +39,6 @@ export interface MasterDataContextValue {
   findGuideByName: (query: string) => Guide | undefined;
   forceSync: () => Promise<void>;
   clearAllData: () => Promise<void>;
-  updateMasterDataBatch: (data: Partial<MasterData>) => void;
-  addServicesBatch: (services: Omit<Service, "id">[]) => void;
-  addGuidesBatch: (guides: Omit<Guide, "id">[]) => void;
-  addPartnersBatch: (partners: Omit<Partner, "id">[]) => void;
-  addPerDiemRatesBatch: (rates: Omit<PerDiemRate, "id">[]) => void;
 }
 
 const MasterDataContext = createContext<MasterDataContextValue | undefined>(
@@ -301,58 +296,6 @@ export const MasterDataProvider = ({ children }: { children: ReactNode }) => {
     }
   };
 
-  const updateMasterDataBatch = async (data: Partial<MasterData>) => {
-    const newData = await updateMasterData(masterData, (current) => ({
-      ...current,
-      ...data,
-    }));
-    setMasterData(newData);
-  };
-
-  const addServicesBatch = async (services: Omit<Service, "id">[]) => {
-    const newData = await updateMasterData(masterData, (current) => ({
-      ...current,
-      services: [
-        ...current.services,
-        ...services.map(service => ({ ...service, id: generateId() })),
-      ],
-    }));
-    setMasterData(newData);
-  };
-
-  const addGuidesBatch = async (guides: Omit<Guide, "id">[]) => {
-    const newData = await updateMasterData(masterData, (current) => ({
-      ...current,
-      guides: [
-        ...current.guides,
-        ...guides.map(guide => ({ ...guide, id: generateId() })),
-      ],
-    }));
-    setMasterData(newData);
-  };
-
-  const addPartnersBatch = async (partners: Omit<Partner, "id">[]) => {
-    const newData = await updateMasterData(masterData, (current) => ({
-      ...current,
-      partners: [
-        ...current.partners,
-        ...partners.map(partner => ({ ...partner, id: generateId() })),
-      ],
-    }));
-    setMasterData(newData);
-  };
-
-  const addPerDiemRatesBatch = async (rates: Omit<PerDiemRate, "id">[]) => {
-    const newData = await updateMasterData(masterData, (current) => ({
-      ...current,
-      perDiemRates: [
-        ...current.perDiemRates,
-        ...rates.map(rate => ({ ...rate, id: generateId() })),
-      ],
-    }));
-    setMasterData(newData);
-  };
-
   const value: MasterDataContextValue = {
     masterData,
     syncStatus,
@@ -376,11 +319,6 @@ export const MasterDataProvider = ({ children }: { children: ReactNode }) => {
     findGuideByName,
     forceSync,
     clearAllData,
-    updateMasterDataBatch,
-    addServicesBatch,
-    addGuidesBatch,
-    addPartnersBatch,
-    addPerDiemRatesBatch,
   };
 
   return (

--- a/client/src/pages/MasterData/MasterDataPage.tsx
+++ b/client/src/pages/MasterData/MasterDataPage.tsx
@@ -1,5 +1,5 @@
-import { useState } from "react";
-import { FiDatabase, FiEdit2, FiPlus, FiRefreshCw, FiSave, FiUsers, FiBriefcase, FiDollarSign, FiList, FiTrash2 } from "react-icons/fi";
+import { useEffect, useState } from "react";
+import { FiDatabase, FiDownload, FiEdit2, FiPlus, FiRefreshCw, FiSave, FiUsers, FiBriefcase, FiDollarSign, FiList, FiTrash2 } from "react-icons/fi";
 import { PageHeader } from "../../components/common/PageHeader";
 import { TabMenu } from "../../components/common/TabMenu";
 import { SyncStatus } from "../../components/common/SyncStatus";
@@ -38,9 +38,9 @@ interface PerDiemFormState {
   notes: string;
 }
 
-const emptyServiceForm = (): ServiceFormState => ({
+const emptyServiceForm = (defaultCategory = ""): ServiceFormState => ({
   name: "",
-  category: "Vé tham quan",
+  category: defaultCategory,
   price: 0,
   unit: "",
   partnerId: "",
@@ -89,7 +89,12 @@ export const MasterDataPage = () => {
     clearAllData,
   } = useMasterData();
 
-  const [serviceForm, setServiceForm] = useState<ServiceFormState>(emptyServiceForm);
+  const serviceTypes = masterData.catalogs.serviceTypes;
+  const defaultServiceCategory = serviceTypes[0] ?? "";
+
+  const [serviceForm, setServiceForm] = useState<ServiceFormState>(() =>
+    emptyServiceForm(defaultServiceCategory),
+  );
   const [guideForm, setGuideForm] = useState<GuideFormState>(emptyGuideForm);
   const [partnerForm, setPartnerForm] = useState<PartnerFormState>(emptyPartnerForm);
   const [perDiemForm, setPerDiemForm] = useState<PerDiemFormState>(emptyPerDiemForm);
@@ -105,6 +110,56 @@ export const MasterDataPage = () => {
   const [showClearDialog, setShowClearDialog] = useState(false);
   const [isClearing, setIsClearing] = useState(false);
 
+  useEffect(() => {
+    setServiceForm((current) => {
+      if (serviceTypes.length === 0) {
+        return current.category === "" ? current : { ...current, category: "" };
+      }
+
+      if (!current.category || !serviceTypes.includes(current.category)) {
+        return { ...current, category: serviceTypes[0] };
+      }
+
+      return current;
+    });
+  }, [serviceTypes]);
+
+  const getServiceTypeOptions = (currentCategory?: string) => {
+    if (currentCategory && serviceTypes.includes(currentCategory)) {
+      return serviceTypes;
+    }
+
+    if (currentCategory && currentCategory !== "") {
+      return [currentCategory, ...serviceTypes];
+    }
+
+    return serviceTypes;
+  };
+
+  const renderCategorySelect = (
+    value: string,
+    onChange: (nextValue: string) => void,
+  ) => {
+    const options = getServiceTypeOptions(value);
+    const hasOptions = options.length > 0;
+
+    return (
+      <select value={value} onChange={(event) => onChange(event.target.value)}>
+        {!hasOptions && <option value="">Chưa có danh mục</option>}
+        {hasOptions && value === "" && (
+          <option value="" disabled>
+            Chọn danh mục
+          </option>
+        )}
+        {options.map((type) => (
+          <option key={type || "blank"} value={type}>
+            {type || "—"}
+          </option>
+        ))}
+      </select>
+    );
+  };
+
   const tabs = [
     { id: "services", label: "Dịch vụ & bảng giá", icon: <FiDatabase /> },
     { id: "guides", label: "Hướng dẫn viên", icon: <FiUsers /> },
@@ -114,7 +169,12 @@ export const MasterDataPage = () => {
   ];
 
   const handleAddService = () => {
-    if (!serviceForm.name.trim() || serviceForm.price <= 0 || !serviceForm.unit.trim()) {
+    if (
+      !serviceForm.name.trim() ||
+      !serviceForm.category ||
+      serviceForm.price <= 0 ||
+      !serviceForm.unit.trim()
+    ) {
       return;
     }
     addService({
@@ -125,12 +185,12 @@ export const MasterDataPage = () => {
       partnerId: serviceForm.partnerId || undefined,
       description: serviceForm.description || undefined,
     });
-    setServiceForm(emptyServiceForm());
+    setServiceForm(emptyServiceForm(serviceTypes[0] ?? ""));
   };
 
   const handleSaveService = () => {
     if (!editingService) return;
-    if (!editingService.name.trim() || editingService.price <= 0) return;
+    if (!editingService.name.trim() || !editingService.category || editingService.price <= 0) return;
     updateService(editingService.id, {
       name: editingService.name.trim(),
       category: editingService.category,
@@ -239,6 +299,91 @@ export const MasterDataPage = () => {
     }
   };
 
+  const exportToTextFile = (filename: string, lines: string[]) => {
+    const content = lines.join("\n");
+    const blob = new Blob([content], { type: "text/plain;charset=utf-8" });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = filename;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  };
+
+  const handleExportServicesTxt = () => {
+    const partnerLookup = new Map(
+      masterData.partners.map((partner) => [partner.id, partner.name] as const),
+    );
+    const header = "Tên dịch vụ\tDanh mục\tGiá\tĐơn vị\tĐối tác\tMô tả";
+    const lines = masterData.services.map((service) => {
+      const partnerName = service.partnerId
+        ? partnerLookup.get(service.partnerId) ?? ""
+        : "";
+      return [
+        service.name,
+        service.category,
+        String(service.price),
+        service.unit,
+        partnerName,
+        service.description ?? "",
+      ].join("\t");
+    });
+    exportToTextFile("services.txt", [header, ...lines]);
+  };
+
+  const handleExportGuidesTxt = () => {
+    const header = "Tên\tĐiện thoại\tEmail\tNgôn ngữ";
+    const lines = masterData.guides.map((guide) =>
+      [
+        guide.name,
+        guide.phone ?? "",
+        guide.email ?? "",
+        (guide.languages ?? []).join(", "),
+      ].join("\t"),
+    );
+    exportToTextFile("guides.txt", [header, ...lines]);
+  };
+
+  const handleExportPartnersTxt = () => {
+    const header = "Tên\tNgười liên hệ\tĐiện thoại\tEmail\tĐịa chỉ";
+    const lines = masterData.partners.map((partner) =>
+      [
+        partner.name,
+        partner.contactName ?? "",
+        partner.phone ?? "",
+        partner.email ?? "",
+        partner.address ?? "",
+      ].join("\t"),
+    );
+    exportToTextFile("partners.txt", [header, ...lines]);
+  };
+
+  const handleExportPerDiemTxt = () => {
+    const header = "Địa điểm\tMức phụ cấp\tTiền tệ\tGhi chú";
+    const lines = masterData.perDiemRates.map((rate) =>
+      [
+        rate.location,
+        String(rate.rate),
+        rate.currency,
+        rate.notes ?? "",
+      ].join("\t"),
+    );
+    exportToTextFile("per-diem.txt", [header, ...lines]);
+  };
+
+  const handleExportCatalogsTxt = () => {
+    const lines = [
+      "[Quốc tịch]",
+      ...masterData.catalogs.nationalities,
+      "",
+      "[Loại dịch vụ]",
+      ...masterData.catalogs.serviceTypes,
+    ];
+    exportToTextFile("catalogs.txt", lines);
+  };
+
   const renderTabContent = () => {
     switch (activeTab) {
       case "services":
@@ -267,6 +412,17 @@ export const MasterDataPage = () => {
         </p>
       </div>
       <div className="panel-body">
+        <div
+          style={{ display: "flex", justifyContent: "flex-end", marginBottom: "1rem" }}
+        >
+          <button
+            type="button"
+            className="ghost-button"
+            onClick={handleExportServicesTxt}
+          >
+            <FiDownload /> Xuất TXT
+          </button>
+        </div>
         <div className="table-responsive">
           <table className="data-table compact">
             <thead>
@@ -298,16 +454,13 @@ export const MasterDataPage = () => {
                   </td>
                   <td>
                     {editingService?.id === service.id ? (
-                      <input
-                        value={editingService.category}
-                        onChange={(event) =>
-                          setEditingService((current) =>
-                            current ? { ...current, category: event.target.value } : current,
-                          )
-                        }
-                      />
+                      renderCategorySelect(editingService.category, (nextValue) =>
+                        setEditingService((current) =>
+                          current ? { ...current, category: nextValue } : current,
+                        ),
+                      )
                     ) : (
-                      service.category
+                      service.category || "—"
                     )}
                   </td>
                   <td>
@@ -409,12 +562,9 @@ export const MasterDataPage = () => {
           </label>
           <label>
             <span>Danh mục</span>
-            <input
-              value={serviceForm.category}
-              onChange={(event) =>
-                setServiceForm((current) => ({ ...current, category: event.target.value }))
-              }
-            />
+            {renderCategorySelect(serviceForm.category, (nextValue) =>
+              setServiceForm((current) => ({ ...current, category: nextValue })),
+            )}
           </label>
           <label>
             <span>Đơn vị</span>
@@ -484,6 +634,17 @@ export const MasterDataPage = () => {
         </p>
       </div>
       <div className="panel-body">
+        <div
+          style={{ display: "flex", justifyContent: "flex-end", marginBottom: "1rem" }}
+        >
+          <button
+            type="button"
+            className="ghost-button"
+            onClick={handleExportGuidesTxt}
+          >
+            <FiDownload /> Xuất TXT
+          </button>
+        </div>
         <div className="table-responsive">
           <table className="data-table compact">
             <thead>
@@ -649,6 +810,17 @@ export const MasterDataPage = () => {
         <div className="panel-title">Đối tác & nhà cung cấp</div>
       </div>
       <div className="panel-body">
+        <div
+          style={{ display: "flex", justifyContent: "flex-end", marginBottom: "1rem" }}
+        >
+          <button
+            type="button"
+            className="ghost-button"
+            onClick={handleExportPartnersTxt}
+          >
+            <FiDownload /> Xuất TXT
+          </button>
+        </div>
         <div className="table-responsive">
           <table className="data-table compact">
             <thead>
@@ -807,6 +979,17 @@ export const MasterDataPage = () => {
         <div className="panel-title">Cấu hình phụ cấp</div>
       </div>
       <div className="panel-body">
+        <div
+          style={{ display: "flex", justifyContent: "flex-end", marginBottom: "1rem" }}
+        >
+          <button
+            type="button"
+            className="ghost-button"
+            onClick={handleExportPerDiemTxt}
+          >
+            <FiDownload /> Xuất TXT
+          </button>
+        </div>
         <div className="table-responsive">
           <table className="data-table compact">
             <thead>
@@ -972,6 +1155,17 @@ export const MasterDataPage = () => {
         </p>
       </div>
       <div className="panel-body">
+        <div
+          style={{ display: "flex", justifyContent: "flex-end", marginBottom: "1rem" }}
+        >
+          <button
+            type="button"
+            className="ghost-button"
+            onClick={handleExportCatalogsTxt}
+          >
+            <FiDownload /> Xuất TXT
+          </button>
+        </div>
         <div className="catalog-grid">
           <div>
             <h3>Quốc tịch</h3>


### PR DESCRIPTION
## Summary
- change the service category inputs to use shared service type dropdowns and default to catalog values
- add reusable helpers and buttons to export each master data tab to line-based TXT files
- drop unused JSON batch methods from the master data context and clean up lint violations in shared utilities

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d37063c69c8323a89e4439a3c44856