### PR TITLE
Update master data category handling and add text exports

### DIFF
--- a/client/src/components/common/ConfirmationDialog.tsx
+++ b/client/src/components/common/ConfirmationDialog.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode } from "react";
+import type { MouseEvent } from "react";
 import { FiAlertTriangle, FiX } from "react-icons/fi";
 
 interface ConfirmationDialogProps {
@@ -57,8 +57,8 @@ export const ConfirmationDialog = ({
 
   const styles = getVariantStyles();
 
-  const handleBackdropClick = (e: React.MouseEvent) => {
-    if (e.target === e.currentTarget) {
+  const handleBackdropClick = (event: MouseEvent<HTMLDivElement>) => {
+    if (event.target === event.currentTarget) {
       onClose();
     }
   };

--- a/client/src/components/common/SyncStatus.tsx
+++ b/client/src/components/common/SyncStatus.tsx
@@ -1,4 +1,4 @@
-import { FiWifi, FiWifiOff, FiRefreshCw, FiCheckCircle, FiAlertTriangle } from "react-icons/fi";
+import { FiWifiOff, FiRefreshCw, FiCheckCircle, FiAlertTriangle } from "react-icons/fi";
 import { useMasterData } from "../../contexts/MasterDataContext";
 
 export const SyncStatus = () => {

--- a/client/src/config/firebase.ts
+++ b/client/src/config/firebase.ts
@@ -1,6 +1,6 @@
 import { initializeApp } from "firebase/app";
-import { getFirestore, connectFirestoreEmulator } from "firebase/firestore";
-import { getAnalytics } from "firebase/analytics";
+import { getFirestore } from "firebase/firestore";
+import { getAnalytics, type Analytics } from "firebase/analytics";
 
 // Firebase configuration
 const firebaseConfig = {
@@ -20,7 +20,7 @@ const app = initializeApp(firebaseConfig);
 export const db = getFirestore(app);
 
 // Initialize Analytics (only in production)
-let analytics: any = null;
+let analytics: Analytics | null = null;
 if (typeof window !== "undefined" && process.env.NODE_ENV === "production") {
   analytics = getAnalytics(app);
 }

--- a/client/src/contexts/MasterDataContext.tsx
+++ b/client/src/contexts/MasterDataContext.tsx
@@ -39,11 +39,6 @@ export interface MasterDataContextValue {
   findGuideByName: (query: string) => Guide | undefined;
   forceSync: () => Promise<void>;
   clearAllData: () => Promise<void>;
-  updateMasterDataBatch: (data: Partial<MasterData>) => void;
-  addServicesBatch: (services: Omit<Service, "id">[]) => void;
-  addGuidesBatch: (guides: Omit<Guide, "id">[]) => void;
-  addPartnersBatch: (partners: Omit<Partner, "id">[]) => void;
-  addPerDiemRatesBatch: (rates: Omit<PerDiemRate, "id">[]) => void;
 }
 
 const MasterDataContext = createContext<MasterDataContextValue | undefined>(
@@ -301,58 +296,6 @@ export const MasterDataProvider = ({ children }: { children: ReactNode }) => {
     }
   };
 
-  const updateMasterDataBatch = async (data: Partial<MasterData>) => {
-    const newData = await updateMasterData(masterData, (current) => ({
-      ...current,
-      ...data,
-    }));
-    setMasterData(newData);
-  };
-
-  const addServicesBatch = async (services: Omit<Service, "id">[]) => {
-    const newData = await updateMasterData(masterData, (current) => ({
-      ...current,
-      services: [
-        ...current.services,
-        ...services.map(service => ({ ...service, id: generateId() })),
-      ],
-    }));
-    setMasterData(newData);
-  };
-
-  const addGuidesBatch = async (guides: Omit<Guide, "id">[]) => {
-    const newData = await updateMasterData(masterData, (current) => ({
-      ...current,
-      guides: [
-        ...current.guides,
-        ...guides.map(guide => ({ ...guide, id: generateId() })),
-      ],
-    }));
-    setMasterData(newData);
-  };
-
-  const addPartnersBatch = async (partners: Omit<Partner, "id">[]) => {
-    const newData = await updateMasterData(masterData, (current) => ({
-      ...current,
-      partners: [
-        ...current.partners,
-        ...partners.map(partner => ({ ...partner, id: generateId() })),
-      ],
-    }));
-    setMasterData(newData);
-  };
-
-  const addPerDiemRatesBatch = async (rates: Omit<PerDiemRate, "id">[]) => {
-    const newData = await updateMasterData(masterData, (current) => ({
-      ...current,
-      perDiemRates: [
-        ...current.perDiemRates,
-        ...rates.map(rate => ({ ...rate, id: generateId() })),
-      ],
-    }));
-    setMasterData(newData);
-  };
-
   const value: MasterDataContextValue = {
     masterData,
     syncStatus,
@@ -376,11 +319,6 @@ export const MasterDataProvider = ({ children }: { children: ReactNode }) => {
     findGuideByName,
     forceSync,
     clearAllData,
-    updateMasterDataBatch,
-    addServicesBatch,
-    addGuidesBatch,
-    addPartnersBatch,
-    addPerDiemRatesBatch,
   };
 
   return (


### PR DESCRIPTION
## Summary
- change the service category inputs to use shared service type dropdowns and default to catalog values
- add reusable helpers and buttons to export each master data tab to line-based `.txt` files with comma-separated columns
- drop unused JSON batch methods from the master data context and clean up lint violations in shared utilities

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d37063c69c8323a89e4439a3c44856