### PR TITLE
Add sample tour JSON download

### DIFF
--- a/client/public/samples/tour-import-sample.json
+++ b/client/public/samples/tour-import-sample.json
@@ -1,0 +1,197 @@
+[
+  {
+    "general": {
+      "tourCode": "SAMPLE-GEM-2408",
+      "customerName": "Gia đình Trần",
+      "clientCompany": "Saigon Travel Partners",
+      "pax": 4,
+      "nationality": "Singapore",
+      "startDate": "2024-08-12T00:00:00.000Z",
+      "endDate": "2024-08-14T00:00:00.000Z",
+      "guideName": "Cao Huu Tu",
+      "driverName": "Mr. Phuc",
+      "notes": "Khách yêu cầu bữa tối chay ngày thứ 2 và hỗ trợ check-in sớm."
+    },
+    "services": [
+      {
+        "rawName": "Ba Na Hills Entrance Ticket",
+        "quantity": 4,
+        "price": 790000,
+        "notes": "Yêu cầu VIP line"
+      },
+      {
+        "rawName": "Han River Dragon Boat",
+        "quantity": 1,
+        "price": 1200000
+      },
+      {
+        "rawName": "Vietnamese Set Menu Dinner",
+        "quantity": 4,
+        "price": 240000,
+        "notes": "Thực đơn chay"
+      }
+    ],
+    "itinerary": [
+      {
+        "day": 1,
+        "date": "2024-08-12T00:00:00.000Z",
+        "location": "Đà Nẵng",
+        "activities": [
+          "Đón sân bay",
+          "Tham quan Ngũ Hành Sơn",
+          "Du thuyền sông Hàn buổi tối"
+        ]
+      },
+      {
+        "day": 2,
+        "date": "2024-08-13T00:00:00.000Z",
+        "location": "Bà Nà Hills",
+        "activities": [
+          "Cáp treo",
+          "Cầu Vàng",
+          "Fantasy Park"
+        ]
+      },
+      {
+        "day": 3,
+        "date": "2024-08-14T00:00:00.000Z",
+        "location": "Hội An",
+        "activities": [
+          "Phố cổ",
+          "Xưởng làm đèn lồng",
+          "Ăn tối nhà hàng chay"
+        ]
+      }
+    ],
+    "otherExpenses": [
+      {
+        "description": "Nước suối cho khách",
+        "amount": 120000,
+        "date": "2024-08-12T00:00:00.000Z"
+      },
+      {
+        "description": "Phí gửi xe Ngũ Hành Sơn",
+        "amount": 50000,
+        "date": "2024-08-12T00:00:00.000Z"
+      }
+    ],
+    "advance": 6000000,
+    "collectionsForCompany": 3500000,
+    "companyTip": 300000
+  },
+  {
+    "general": {
+      "code": "DAD-SAMPLE-2408",
+      "customerName": "Smith Family",
+      "clientCompany": "Global Holidays",
+      "nationality": "United States",
+      "pax": 2,
+      "startDate": "2024-08-18T00:00:00.000Z",
+      "endDate": "2024-08-20T00:00:00.000Z",
+      "guideId": "guide-lan-anh",
+      "driverName": "Mr. Thanh",
+      "notes": "Kỷ niệm 10 năm ngày cưới, cần bàn ăn riêng tại Hội An."
+    },
+    "itinerary": [
+      {
+        "id": "itn-day-1",
+        "day": 1,
+        "date": "2024-08-18T00:00:00.000Z",
+        "location": "Đà Nẵng",
+        "activities": [
+          "Đón sân bay và nhận phòng",
+          "Tham quan Bảo tàng Chăm",
+          "Ăn tối tại nhà hàng địa phương"
+        ]
+      },
+      {
+        "id": "itn-day-2",
+        "day": 2,
+        "date": "2024-08-19T00:00:00.000Z",
+        "location": "Bà Nà Hills",
+        "activities": [
+          "Cáp treo lên đỉnh",
+          "Chụp ảnh Cầu Vàng",
+          "Buffet trưa"
+        ]
+      },
+      {
+        "id": "itn-day-3",
+        "day": 3,
+        "date": "2024-08-20T00:00:00.000Z",
+        "location": "Hội An",
+        "activities": [
+          "Tham quan phố cổ",
+          "Workshop làm lồng đèn",
+          "Bữa tối kỷ niệm"
+        ]
+      }
+    ],
+    "services": [
+      {
+        "id": "svc-item-1",
+        "serviceId": "svc-airport-transfer",
+        "description": "Da Nang Airport Transfer",
+        "quantity": 1,
+        "unitPrice": 550000,
+        "sourcePrice": 550000,
+        "discrepancy": 0,
+        "notes": "Đón sân bay bằng xe 7 chỗ"
+      },
+      {
+        "id": "svc-item-2",
+        "serviceId": "svc-bana-ticket",
+        "description": "Ba Na Hills Entrance Ticket",
+        "quantity": 2,
+        "unitPrice": 800000,
+        "sourcePrice": 780000,
+        "discrepancy": 20000,
+        "notes": "Giá đối tác ưu đãi"
+      },
+      {
+        "id": "svc-item-3",
+        "serviceId": "svc-vietnamese-set-menu",
+        "description": "Vietnamese Set Menu Dinner",
+        "quantity": 2,
+        "unitPrice": 250000,
+        "sourcePrice": 250000,
+        "discrepancy": 0,
+        "notes": "Bố trí bàn riêng"
+      }
+    ],
+    "perDiem": [
+      {
+        "id": "perdiem-1",
+        "guideId": "guide-lan-anh",
+        "location": "Đà Nẵng",
+        "days": 2,
+        "rate": 450000,
+        "total": 900000
+      },
+      {
+        "id": "perdiem-2",
+        "guideId": "guide-lan-anh",
+        "location": "Hội An",
+        "days": 1,
+        "rate": 500000,
+        "total": 500000
+      }
+    ],
+    "otherExpenses": [
+      {
+        "id": "expense-1",
+        "description": "Hoa chúc mừng đặt trên bàn ăn",
+        "amount": 350000,
+        "date": "2024-08-20T00:00:00.000Z",
+        "notes": "Thanh toán tiền mặt"
+      }
+    ],
+    "financials": {
+      "advance": 5500000,
+      "collectionsForCompany": 4200000,
+      "companyTip": 500000,
+      "totalCost": 0,
+      "differenceToAdvance": 0
+    }
+  }
+]

--- a/client/src/pages/NewTour/NewTourPage.tsx
+++ b/client/src/pages/NewTour/NewTourPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import {
   FiAlertTriangle,
   FiCheckCircle,
+  FiDownload,
   FiFilePlus,
   FiFileText,
   FiRefreshCw,
@@ -434,6 +435,9 @@ export const NewTourPage = () => {
             <p className="panel-description">
               Hoặc tải tệp JSON đã chuẩn hóa để thêm tour hàng loạt hoặc điền sẵn dữ liệu kiểm tra trước khi xác nhận.
             </p>
+            <p className="panel-description">
+              Nhấn nút Tải JSON mẫu để tải về ví dụ đúng cấu trúc cho quá trình nhập liệu.
+            </p>
           </div>
           <div className="panel-body upload-zone">
             <label className="upload-dropzone">
@@ -475,6 +479,13 @@ export const NewTourPage = () => {
                 hidden
                 onChange={handleJsonImport}
               />
+              <a
+                className="ghost-button"
+                href="/samples/tour-import-sample.json"
+                download="tour-import-sample.json"
+              >
+                <FiDownload /> Tải JSON mẫu
+              </a>
               {(uploadSource || matches.length > 0 || itinerary.length > 0 || otherExpenses.length > 0) && (
                 <button className="ghost-button" type="button" onClick={handleReset}>
                   Đặt lại


### PR DESCRIPTION
## Summary
- add a sample tour JSON file that includes a Gemini extraction payload and a ready-to-import tour example
- update the AI intake page with messaging and a button that downloads the sample JSON directly from the app

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d381903d948323b231876d0354e06d