### PR TITLE
Ensure prompt editing pulls latest Firebase prompt

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -2049,14 +2049,14 @@ textarea:focus-visible {
   box-shadow: var(--shadow-lg);
   max-width: 600px;
   width: 100%;
-  max-height: 90vh;
+  max-height: 95vh;
   overflow: hidden;
   display: flex;
   flex-direction: column;
 }
 
 .modal-content.large {
-  max-width: 800px;
+  max-width: min(100%, 960px);
 }
 
 .modal-header {
@@ -2112,6 +2112,18 @@ textarea:focus-visible {
   font-size: 0.875rem;
   line-height: 1.5;
   resize: vertical;
+  width: 100%;
+  min-height: 18rem;
+}
+
+@media (min-width: 1024px) {
+  .modal-content.large {
+    max-width: 1100px;
+  }
+
+  .prompt-textarea {
+    min-height: 28rem;
+  }
 }
 
 .prompt-help {

--- a/client/src/components/common/PromptManager.tsx
+++ b/client/src/components/common/PromptManager.tsx
@@ -1,8 +1,8 @@
-import { useState, useEffect } from "react";
-import { FiPlus, FiEdit, FiTrash2, FiRefreshCw, FiAlertTriangle, FiCheckCircle } from "react-icons/fi";
+import { useState, useEffect, useCallback } from "react";
+import { FiEdit, FiRefreshCw, FiAlertTriangle, FiCheckCircle } from "react-icons/fi";
+import type { Timestamp } from "firebase/firestore";
 import type { Prompt } from "../../types/prompt";
-import { getAllPrompts, deletePrompt } from "../../services/promptService";
-import { createDetailedPrompt } from "../../services/detailedPromptService";
+import { getLatestPrompt } from "../../services/promptService";
 import { PromptModal } from "./PromptModal";
 
 interface PromptManagerProps {
@@ -10,102 +10,111 @@ interface PromptManagerProps {
 }
 
 export const PromptManager = ({ onPromptChange }: PromptManagerProps) => {
-  const [prompts, setPrompts] = useState<Prompt[]>([]);
+  const [currentPrompt, setCurrentPrompt] = useState<Prompt | null>(null);
   const [loading, setLoading] = useState(false);
+  const [refreshing, setRefreshing] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [modalOpen, setModalOpen] = useState(false);
   const [editingPrompt, setEditingPrompt] = useState<Prompt | null>(null);
 
-  const loadPrompts = async () => {
-    setLoading(true);
-    setError(null);
-    try {
-      const promptsData = await getAllPrompts();
-      setPrompts(promptsData);
-    } catch (error) {
-      console.error("Error loading prompts:", error);
-      setError(error instanceof Error ? error.message : "Không thể tải danh sách prompts");
-    } finally {
-      setLoading(false);
+  const loadLatestPrompt = useCallback(async (options?: { silent?: boolean }) => {
+    if (options?.silent) {
+      setRefreshing(true);
+    } else {
+      setLoading(true);
     }
-  };
+    setError(null);
 
-  useEffect(() => {
-    loadPrompts();
+    try {
+      const prompt = await getLatestPrompt();
+      setCurrentPrompt(prompt);
+      return prompt;
+    } catch (error) {
+      console.error("Error loading prompt:", error);
+      setError(error instanceof Error ? error.message : "Không thể tải prompt mới nhất");
+      return null;
+    } finally {
+      if (options?.silent) {
+        setRefreshing(false);
+      } else {
+        setLoading(false);
+      }
+    }
   }, []);
 
-  const handleCreatePrompt = () => {
-    setEditingPrompt(null);
-    setModalOpen(true);
+  useEffect(() => {
+    void loadLatestPrompt();
+  }, [loadLatestPrompt]);
+
+  const handleRefresh = () => {
+    void loadLatestPrompt();
   };
 
-  const handleEditPrompt = (prompt: Prompt) => {
+  const handleEditPrompt = async () => {
+    const prompt = await loadLatestPrompt({ silent: true });
+    if (!prompt) {
+      setError("Không tìm thấy prompt để chỉnh sửa.");
+      return;
+    }
+
     setEditingPrompt(prompt);
     setModalOpen(true);
   };
 
-  const handleDeletePrompt = async (promptId: string) => {
-    if (!confirm("Bạn có chắc chắn muốn xóa prompt này?")) {
-      return;
-    }
-
-    try {
-      await deletePrompt(promptId);
-      await loadPrompts();
-      onPromptChange?.();
-    } catch (error) {
-      console.error("Error deleting prompt:", error);
-      setError(error instanceof Error ? error.message : "Không thể xóa prompt");
-    }
+  const handleModalClose = () => {
+    setModalOpen(false);
+    setEditingPrompt(null);
   };
 
-  const handleCreateDetailedPrompt = async () => {
-    try {
-      await createDetailedPrompt();
-      await loadPrompts();
-      onPromptChange?.();
-    } catch (error) {
-      console.error("Error creating detailed prompt:", error);
-      setError(error instanceof Error ? error.message : "Không thể tạo prompt chi tiết");
-    }
-  };
-
-  const handleModalSave = () => {
-    loadPrompts();
+  const handleModalSave = async () => {
+    await loadLatestPrompt({ silent: true });
     onPromptChange?.();
   };
 
-  const formatDate = (timestamp: any) => {
-    if (!timestamp) return "N/A";
-    const date = timestamp.toDate ? timestamp.toDate() : new Date(timestamp);
-    return date.toLocaleString("vi-VN");
+  const formatDate = (value: Timestamp | Date | string | number | null | undefined) => {
+    if (!value) return "N/A";
+
+    if (value instanceof Date) {
+      return value.toLocaleString("vi-VN");
+    }
+
+    if (typeof value === "string" || typeof value === "number") {
+      const date = new Date(value);
+      return Number.isNaN(date.getTime()) ? "N/A" : date.toLocaleString("vi-VN");
+    }
+
+    if (typeof value === "object" && "toDate" in value && typeof value.toDate === "function") {
+      return value.toDate().toLocaleString("vi-VN");
+    }
+
+    return "N/A";
   };
 
   return (
     <div className="prompt-manager">
       <div className="prompt-manager-header">
         <div className="section-title">
-          <span>Quản lý Prompts</span>
+          <span>Prompt Gemini AI</span>
           <div className="prompt-actions">
             <button
               className="ghost-button small"
-              onClick={handleCreateDetailedPrompt}
-              disabled={loading}
+              onClick={handleRefresh}
+              disabled={loading || refreshing}
+              title="Tải prompt mới nhất"
             >
-              <FiRefreshCw /> Chi tiết
+              <FiRefreshCw className={refreshing ? "spin" : undefined} /> Làm mới
             </button>
             <button
               className="primary-button small"
-              onClick={handleCreatePrompt}
-              disabled={loading}
+              onClick={handleEditPrompt}
+              disabled={loading || refreshing || !currentPrompt}
             >
-              <FiPlus /> Tạo mới
+              <FiEdit /> Chỉnh sửa
             </button>
           </div>
         </div>
         <p className="section-description">
-          Quản lý các prompt để tùy chỉnh cách Gemini AI trích xuất dữ liệu từ hình ảnh tour.
-          Prompt mới nhất sẽ được sử dụng cho việc trích xuất.
+          Prompt mới nhất được lưu trên Firebase sẽ được sử dụng cho mọi lần trích xuất Gemini.
         </p>
       </div>
 
@@ -118,72 +127,41 @@ export const PromptManager = ({ onPromptChange }: PromptManagerProps) => {
       {loading ? (
         <div className="loading-state">
           <FiRefreshCw className="spin" />
-          <span>Đang tải prompts...</span>
+          <span>Đang tải prompt mới nhất...</span>
         </div>
-      ) : prompts.length === 0 ? (
+      ) : currentPrompt ? (
+        <div className="prompt-preview-section">
+          <div className="prompt-header">
+            <h3 className="prompt-title">
+              {currentPrompt.name}
+              {currentPrompt.isActive && <FiCheckCircle className="active-indicator" />}
+            </h3>
+            <div className="prompt-meta">
+              <span className="prompt-date">Cập nhật: {formatDate(currentPrompt.updatedAt)}</span>
+              <span className="prompt-size">{currentPrompt.content.length} ký tự</span>
+            </div>
+          </div>
+
+          <div className="prompt-description">
+            <strong>Mô tả:</strong> {currentPrompt.description}
+          </div>
+
+          <div className="prompt-content-preview">
+            <h4>Nội dung prompt:</h4>
+            <div className="prompt-content-display">{currentPrompt.content}</div>
+          </div>
+        </div>
+      ) : (
         <div className="empty-state">
           <FiAlertTriangle />
           <h3>Chưa có prompt nào</h3>
-          <p>Hãy tạo prompt đầu tiên để bắt đầu sử dụng tính năng trích xuất AI.</p>
-          <button className="primary-button" onClick={handleCreateDetailedPrompt}>
-            <FiPlus /> Tạo prompt chi tiết
-          </button>
-        </div>
-      ) : (
-        <div className="prompts-list">
-          {prompts.map((prompt) => (
-            <div key={prompt.id} className="prompt-item">
-              <div className="prompt-header">
-                <div className="prompt-info">
-                  <h4 className="prompt-name">
-                    {prompt.name}
-                    {prompt.isActive && <FiCheckCircle className="active-indicator" />}
-                  </h4>
-                  <p className="prompt-description">{prompt.description}</p>
-                </div>
-                <div className="prompt-actions">
-                  <button
-                    className="ghost-button small"
-                    onClick={() => handleEditPrompt(prompt)}
-                    title="Chỉnh sửa"
-                  >
-                    <FiEdit />
-                  </button>
-                  <button
-                    className="ghost-button small danger"
-                    onClick={() => handleDeletePrompt(prompt.id)}
-                    title="Xóa"
-                  >
-                    <FiTrash2 />
-                  </button>
-                </div>
-              </div>
-              
-              <div className="prompt-content">
-                <div className="prompt-preview">
-                  {prompt.content.length > 200 
-                    ? `${prompt.content.substring(0, 200)}...` 
-                    : prompt.content
-                  }
-                </div>
-              </div>
-              
-              <div className="prompt-meta">
-                <span className="prompt-date">
-                  Cập nhật: {formatDate(prompt.updatedAt)}
-                </span>
-                <span className="prompt-size">
-                  {prompt.content.length} ký tự
-                </span>
-              </div>
-            </div>
-          ))}
+          <p>Vui lòng thêm prompt vào Firebase để sử dụng cùng Gemini AI.</p>
         </div>
       )}
 
       <PromptModal
         isOpen={modalOpen}
-        onClose={() => setModalOpen(false)}
+        onClose={handleModalClose}
         prompt={editingPrompt}
         onSave={handleModalSave}
       />


### PR DESCRIPTION
## Summary
- load the latest Gemini prompt from Firestore on mount/refresh and remove the prompt creation actions
- limit the prompt modal to updating the existing Firestore entry and enlarge the editing form
- widen the modal layout and textarea on desktop for more comfortable prompt editing

## Testing
- npm run lint *(fails: existing lint issues in untouched files)*

------
https://chatgpt.com/codex/tasks/task_e_68d3acdc9b00832391b721812e6535d7