### PR TITLE
feat: add general info overrides for AI extraction

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -548,6 +548,161 @@
   flex-wrap: wrap;
 }
 
+.extraction-hints {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1.25rem;
+  border-radius: var(--radius-md);
+  background: rgba(37, 99, 235, 0.04);
+  border: 1px solid rgba(37, 99, 235, 0.15);
+}
+
+.extraction-hints-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.extraction-hints-title {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 600;
+  color: #1f2937;
+}
+
+.extraction-hints-title svg {
+  color: var(--color-primary);
+}
+
+.extraction-hints-header p {
+  margin: 0;
+  color: #475569;
+  font-size: 0.85rem;
+}
+
+.extraction-hints-status {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.extraction-hints-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.extraction-hints-meta small {
+  color: #64748b;
+  font-size: 0.75rem;
+}
+
+.badge.neutral {
+  background: rgba(148, 163, 184, 0.18);
+  color: #475569;
+}
+
+.new-tour-page .extraction-grid {
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.form-grid label small {
+  color: #94a3b8;
+  font-size: 0.75rem;
+  font-weight: 500;
+}
+
+.extraction-reference {
+  border-radius: var(--radius-md);
+  background: rgba(15, 23, 42, 0.03);
+  border: 1px dashed rgba(148, 163, 184, 0.35);
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.extraction-reference-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.extraction-reference-title {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.extraction-reference-title svg {
+  color: var(--color-primary);
+}
+
+.extraction-reference-header p {
+  margin: 0;
+  color: #475569;
+  font-size: 0.82rem;
+}
+
+.extraction-reference-grid {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.extraction-reference-item {
+  background: rgba(255, 255, 255, 0.75);
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  padding: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.extraction-reference-item-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.extraction-reference-item-header code {
+  font-weight: 600;
+  font-size: 0.85rem;
+  color: #0f172a;
+}
+
+.reference-type {
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #2563eb;
+  background: rgba(37, 99, 235, 0.1);
+  padding: 0.2rem 0.45rem;
+  border-radius: 999px;
+}
+
+.extraction-reference-item p {
+  margin: 0;
+  color: #475569;
+  font-size: 0.78rem;
+  line-height: 1.45;
+}
+
+.extraction-reference-item .badge {
+  align-self: flex-start;
+  font-size: 0.7rem;
+  padding: 0.2rem 0.6rem;
+}
+
 .sticky-actions {
   position: sticky;
   top: 0;

--- a/client/src/utils/extraction.ts
+++ b/client/src/utils/extraction.ts
@@ -1,4 +1,5 @@
 import type {
+  ExtractionGeneralInfo,
   ExtractionResult,
   MasterData,
   MatchedService,
@@ -13,8 +14,54 @@ const normalize = (value: string) =>
     .replace(/\p{Diacritic}/gu, "")
     .trim();
 
+const mergeGeneralOverrides = (
+  base: ExtractionGeneralInfo,
+  overrides?: Partial<ExtractionGeneralInfo>,
+): ExtractionGeneralInfo => {
+  if (!overrides) {
+    return base;
+  }
+
+  const trimmed = (value: string | undefined) => value?.trim() ?? "";
+  const merged: ExtractionGeneralInfo = { ...base };
+
+  if (trimmed(overrides.tourCode)) {
+    merged.tourCode = trimmed(overrides.tourCode);
+  }
+  if (trimmed(overrides.customerName)) {
+    merged.customerName = trimmed(overrides.customerName);
+  }
+  if (trimmed(overrides.clientCompany)) {
+    merged.clientCompany = trimmed(overrides.clientCompany);
+  }
+  if (typeof overrides.pax === "number" && Number.isFinite(overrides.pax)) {
+    merged.pax = overrides.pax;
+  }
+  if (trimmed(overrides.nationality)) {
+    merged.nationality = trimmed(overrides.nationality);
+  }
+  if (overrides.startDate) {
+    merged.startDate = overrides.startDate;
+  }
+  if (overrides.endDate) {
+    merged.endDate = overrides.endDate;
+  }
+  if (trimmed(overrides.guideName)) {
+    merged.guideName = trimmed(overrides.guideName);
+  }
+  if (trimmed(overrides.driverName)) {
+    merged.driverName = trimmed(overrides.driverName);
+  }
+  if (trimmed(overrides.notes)) {
+    merged.notes = trimmed(overrides.notes);
+  }
+
+  return merged;
+};
+
 export const simulateGeminiExtraction = (
   _masterData: MasterData,
+  overrides?: Partial<ExtractionGeneralInfo>,
 ): ExtractionResult => {
   void _masterData;
   const today = new Date();
@@ -22,20 +69,22 @@ export const simulateGeminiExtraction = (
   const end = new Date(start);
   end.setDate(start.getDate() + 2);
 
+  const baseGeneral: ExtractionGeneralInfo = {
+    tourCode: `GEM-${start.getFullYear()}-${String(start.getMonth() + 1).padStart(2, "0")}-0${start.getDate()}`,
+    customerName: "Lim Family",
+    clientCompany: "Asia Travel Partners",
+    pax: 4,
+    nationality: "Singapore",
+    startDate: start.toISOString(),
+    endDate: end.toISOString(),
+    guideName: "Tu",
+    driverName: "Mr. Phuc",
+    notes:
+      "Client requested vegetarian dinner option on day 2 and VIP queue for Ba Na cable car.",
+  };
+
   return {
-    general: {
-      tourCode: `GEM-${start.getFullYear()}-${String(start.getMonth() + 1).padStart(2, "0")}-0${start.getDate()}`,
-      customerName: "Lim Family",
-      clientCompany: "Asia Travel Partners",
-      pax: 4,
-      nationality: "Singapore",
-      startDate: start.toISOString(),
-      endDate: end.toISOString(),
-      guideName: "Tu",
-      driverName: "Mr. Phuc",
-      notes:
-        "Client requested vegetarian dinner option on day 2 and VIP queue for Ba Na cable car.",
-    },
+    general: mergeGeneralOverrides(baseGeneral, overrides),
     services: [
       {
         rawName: "Bana Ticket",


### PR DESCRIPTION
## Summary
- add a guided form in the AI upload panel so operators can provide tour general info hints and view the ExtractionGeneralInfo schema
- forward the optional overrides into buildGeneralInfo and the mock extractor to prioritise manual inputs during normalization
- style the new override helper card and definition list to match the existing new tour experience

## Testing
- npm run lint *(fails: existing lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d3f7f8fdb483238f079a70f128549a