### PR TITLE
Fix TypeScript build issues and improve settings reset

### DIFF
--- a/client/src/components/common/ApiKeySettings.tsx
+++ b/client/src/components/common/ApiKeySettings.tsx
@@ -5,9 +5,10 @@ import { saveApiKey, loadApiKey, saveApiMode, loadApiMode } from "../../services
 interface ApiKeySettingsProps {
   onApiKeyChange?: (key: string) => void;
   onApiModeChange?: (mode: "mock" | "live") => void;
+  resetSignal?: number;
 }
 
-export const ApiKeySettings = ({ onApiKeyChange, onApiModeChange }: ApiKeySettingsProps) => {
+export const ApiKeySettings = ({ onApiKeyChange, onApiModeChange, resetSignal }: ApiKeySettingsProps) => {
   const [apiKey, setApiKey] = useState("");
   const [showApiKey, setShowApiKey] = useState(false);
   const [apiMode, setApiMode] = useState<"mock" | "live">("mock");
@@ -22,6 +23,19 @@ export const ApiKeySettings = ({ onApiKeyChange, onApiModeChange }: ApiKeySettin
     setApiKey(savedKey);
     setApiMode(savedMode);
   }, []);
+
+  useEffect(() => {
+    if (resetSignal === undefined) {
+      return;
+    }
+
+    const savedKey = loadApiKey();
+    const savedMode = loadApiMode();
+    setApiKey(savedKey);
+    setApiMode(savedMode);
+    setValidationStatus("idle");
+    setValidationMessage("");
+  }, [resetSignal]);
 
   const handleApiKeyChange = (value: string) => {
     setApiKey(value);
@@ -69,12 +83,6 @@ export const ApiKeySettings = ({ onApiKeyChange, onApiModeChange }: ApiKeySettin
     } finally {
       setIsValidating(false);
     }
-  };
-
-  const getApiKeyDisplay = () => {
-    if (!apiKey) return "";
-    if (showApiKey) return apiKey;
-    return "•".repeat(Math.min(apiKey.length, 20));
   };
 
   const getValidationIcon = () => {

--- a/client/src/pages/Settings/SettingsPage.tsx
+++ b/client/src/pages/Settings/SettingsPage.tsx
@@ -2,17 +2,20 @@ import { useState } from "react";
 import { FiSettings, FiSave, FiRefreshCw } from "react-icons/fi";
 import { PageHeader } from "../../components/common/PageHeader";
 import { ApiKeySettings } from "../../components/common/ApiKeySettings";
-import { saveApiKey, loadApiKey, saveApiMode, loadApiMode } from "../../services/aiExtraction";
+import { loadApiKey, loadApiMode } from "../../services/aiExtraction";
 
 export const SettingsPage = () => {
   const [hasChanges, setHasChanges] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
+  const [resetSignal, setResetSignal] = useState(0);
 
   const handleApiKeyChange = (key: string) => {
+    void key;
     setHasChanges(true);
   };
 
   const handleApiModeChange = (mode: "mock" | "live") => {
+    void mode;
     setHasChanges(true);
   };
 
@@ -30,8 +33,7 @@ export const SettingsPage = () => {
   };
 
   const handleReset = () => {
-    const savedKey = loadApiKey();
-    const savedMode = loadApiMode();
+    setResetSignal((value) => value + 1);
     setHasChanges(false);
   };
 
@@ -53,9 +55,10 @@ export const SettingsPage = () => {
             </p>
           </div>
           <div className="panel-body">
-            <ApiKeySettings 
+            <ApiKeySettings
               onApiKeyChange={handleApiKeyChange}
               onApiModeChange={handleApiModeChange}
+              resetSignal={resetSignal}
             />
             
             <div className="settings-actions">

--- a/client/src/services/geminiGeneralFields.ts
+++ b/client/src/services/geminiGeneralFields.ts
@@ -69,16 +69,16 @@ export const listFields = async (): Promise<GeminiGeneralField[]> => {
   return snapshot.docs.map(parseField);
 };
 
-function scrubUndefined<T extends Record<string, unknown>>(obj: T): Record<string, unknown> {
+function scrubUndefined<T extends object>(obj: T): Record<string, unknown> {
   const out: Record<string, unknown> = {};
-  Object.entries(obj).forEach(([k, v]) => {
+  Object.entries(obj as Record<string, unknown>).forEach(([k, v]) => {
     if (v === undefined) return; // Firestore disallows undefined
     out[k] = v;
   });
   return out;
 }
 
-function buildCreatePayload(input: GeminiGeneralFieldInput) {
+function buildCreatePayload(input: Partial<GeminiGeneralFieldInput>) {
   const base = scrubUndefined(input);
   // Only keep options for select and if it's a real array
   if (base.type !== "select") {
@@ -100,7 +100,7 @@ export const createField = async (input: GeminiGeneralFieldInput): Promise<strin
 };
 
 export const updateField = async (id: string, updates: Partial<GeminiGeneralFieldInput>): Promise<void> => {
-  const clean = buildCreatePayload(updates as GeminiGeneralFieldInput);
+  const clean = buildCreatePayload(updates);
   const payload: Record<string, unknown> = { ...clean, updatedAt: serverTimestamp() };
   await setDoc(doc(collectionRef, id), payload, { merge: true });
 };


### PR DESCRIPTION
## Summary
- add a reset signal to the API key settings widget so the reset button restores saved values
- tighten Gemini suggestion field typing and sanitise custom field keys before persisting
- resolve TypeScript errors by removing unused override helpers, relaxing Firestore payload typing, and deleting an unused hybrid sync method

## Testing
- npm run build --prefix client

------
https://chatgpt.com/codex/tasks/task_e_68d689b4680c83239dae8c20766c352e